### PR TITLE
Fix threshold comparisons and related messages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME=aggregated_check
-VERSION=0.0.1
+VERSION=0.0.2
 
 .PHONY: package
 package:

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Aggcheck.Mixfile do
 
   def project do
     [app: :aggcheck,
-     version: "0.0.1",
+     version: "0.0.2",
      language: :erlang,
      escript: escript,
      deps: deps]

--- a/src/aggcheck.erl
+++ b/src/aggcheck.erl
@@ -113,8 +113,8 @@ count_checks(ResultList) ->
 % given a set of check counts, and a check to look for, determine whether we're above/below that threshold
 check_threshold(Counts, TargetState, Threshold, OrderMode) ->
   case {lists:keyfind(TargetState, 1, Counts),OrderMode} of
-    {{_State, Count}, OrderMode} when Count >= Threshold andalso OrderMode == "max" -> true;
-    {{_State, Count}, OrderMode} when Count <  Threshold andalso OrderMode == "max" -> false;
+    {{_State, Count}, OrderMode} when Count >  Threshold andalso OrderMode == "max" -> true;
+    {{_State, Count}, OrderMode} when Count <= Threshold andalso OrderMode == "max" -> false;
     {{_State, Count}, OrderMode} when Count >= Threshold andalso OrderMode == "min" -> false;
     {{_State, Count}, OrderMode} when Count <  Threshold andalso OrderMode == "min" -> true
   end.
@@ -127,10 +127,10 @@ alert_message(Counts, TargetState, WarnThreshold, CritThreshold, ThresholdType, 
     ok       -> WarnThreshold
   end,
   OrderWord = case {OrderMode,ThresholdType} of
-    {"min",ok} -> "is greater than warning(" ++ integer_to_list(WarnThreshold) ++ ") and critical(" ++ integer_to_list(CritThreshold) ++ ") thresholds";
-    {"max",ok} -> "is less than warning(" ++ integer_to_list(WarnThreshold) ++ ") and critical(" ++ integer_to_list(CritThreshold) ++ ") thresholds";
-    {"min",_} ->  "is less than or equal to" ++ " " ++ OrderMode ++ " " ++ atom_to_list(ThresholdType) ++ " threshold of " ++ integer_to_list(ThresholdViolated);
-    {"max",_} ->  "is greater than or equal to" ++ " " ++ OrderMode ++ " " ++ atom_to_list(ThresholdType) ++ " threshold of " ++ integer_to_list(ThresholdViolated)
+    {"min",ok} -> "is greater than or equal to warning(" ++ integer_to_list(WarnThreshold) ++ ") and critical(" ++ integer_to_list(CritThreshold) ++ ") thresholds";
+    {"max",ok} -> "is less than or equal to warning(" ++ integer_to_list(WarnThreshold) ++ ") and critical(" ++ integer_to_list(CritThreshold) ++ ") thresholds";
+    {"min",_} ->  "is less than " ++ OrderMode ++ " " ++ atom_to_list(ThresholdType) ++ " threshold of " ++ integer_to_list(ThresholdViolated);
+    {"max",_} ->  "is greater than " ++ OrderMode ++ " " ++ atom_to_list(ThresholdType) ++ " threshold of " ++ integer_to_list(ThresholdViolated)
   end,
   {TargetState, CheckCount} = lists:keyfind(TargetState, 1, Counts),
   {total, TotalCount} = lists:keyfind(total, 1, Counts),


### PR DESCRIPTION
This changes threshold comparisons so that a count that is equal to a max threshold is considered within bounds. In other words, when order is max, then the check succeeds iff count <= threshold.

This also changes the message produced to reflect the threshold comparisons.

Sorry, my head is not producing comprehensible words at the moment. I might have this all wrong. Also, I didn't test it, because I'm low on time and I don't actually know Erlang.

I can probably resolve all of that later… but it might be easier if you just considered this a bug report. :) Assuming it makes any sense at all.
